### PR TITLE
Ti 1231 vulnerability resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "multer": "^1.0.6",
     "parseurl": "^1.3.0",
     "qs": "^6.4.0",
-    "sway": "^1.0.0",
+    "sway": "^2.0.0",
     "type-is": "^1.6.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node-runner",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Swagger loader and middleware utilities",
   "keywords": [
     "swagger",


### PR DESCRIPTION
This is for resolving vulnerabilities in requestor-proxy.  swagger-node-runner still has not been updated in years, so we need to stay with our fork.  

Will create a tag and version v0.7.5 when this is merged, and it should update.

The sway version seems to correspond exactly to the major Swagger version (and we use 2.0 in requestor-proxy now), and I wasn't able to find any 'breaking' changes for this version update.